### PR TITLE
Add version flag support to root command

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/seashell/cobra"
+	"github.com/seashell/drago/version"
 )
 
 // Used for context
@@ -19,13 +20,16 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "drago",
 		Short: "A flexible configuration manager for Wireguard networks",
-		Long:  `Usage: drago [-version] [-help] [-autocomplete-(un)install] <command> [args]`,
+		Long:  `Usage: drago [--version] [--help] [--autocomplete-(un)install] <command> [args]`,
+		Version: version.GetVersion().VersionNumber(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			config := LoadConfigFromFile(configFile)
 			ctx := context.WithValue(cmd.Context(), ctxKeyType("config"), config)
 			cmd.SetContext(ctx)
 		},
 	}
+
+	cmd.SetVersionTemplate("Drago {{.Version}}")
 
 	cmd.PersistentFlags().StringVarP(&configFile, "config", "", "/etc/drago.d", "config file (default is /etc/drago.d)")
 


### PR DESCRIPTION
Provide drago binary with a version flag, i.e drago --version
Relevant for smoke tests when installing drago in highly automated environments.