### PR TITLE
Docker tweaks (mostly upgrades)

### DIFF
--- a/build/Dockerfile.builder
+++ b/build/Dockerfile.builder
@@ -1,21 +1,13 @@
-FROM golang:1.16.2-stretch as drago-builder
+FROM golang:1.17.0-alpine3.14 as builder
 
 ARG HOST_UID=${HOST_UID}
 ARG HOST_USER=${HOST_USER}
 
-RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb http://dl.yarnpkg.com/debian/ stable main" |  tee /etc/apt/sources.list.d/yarn.list && \
-    curl -sL http://deb.nodesource.com/setup_15.x | bash - && \
-    apt-get install -y nodejs && \
-    apt-get update && \
-    apt-get remove cmdtest && \
-    apt-get install -y yarn
-
-RUN apt-get install -y gcc-arm-linux-gnueabihf libc6-dev-armhf-cross \
-                       gcc-aarch64-linux-gnu libc6-dev-arm64-cross
+RUN apk add nodejs npm && \
+    npm install -g yarn
 
 RUN if [ "${HOST_USER}" != "root" ]; then \
-    (adduser -q --gecos "" --home /home/${HOST_USER} --disabled-password -u ${HOST_UID} ${HOST_USER} \
+    (adduser --gecos "" --home /home/${HOST_USER} --disabled-password -u ${HOST_UID} ${HOST_USER} \
     && chown -R "${HOST_UID}:${HOST_UID}" /home/${HOST_USER}); \
     fi
 

--- a/build/Dockerfile.linux_amd64
+++ b/build/Dockerfile.linux_amd64
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 
 WORKDIR /home
 


### PR DESCRIPTION
Changes in this PR:
- Upgrade builder image to Go 1.17.0 (everything builds successfully with this version)
- Switch to alpine for builder image (takes less space and less time to build; everything builds correctly and works on non-alpine Linux systems too - confirmed on openSUSE Tumbleweed)
- Simplify builder Dockerfile significantly (no custom repos or compiler toolchains needed)
- Upgrade to Alpine 3.14 for linux_amd64 image

I've confirmed that the above changes build successfully